### PR TITLE
Update repository URL

### DIFF
--- a/sed.html
+++ b/sed.html
@@ -136,7 +136,7 @@
 
         <li><a href="http://sed.godrago.net/pythonsed-1.00.zip">Download sed.py and help page</a></li>
         <li><a href="http://sed.godrago.net/pythonsed-tests-1.00.zip">Download testing script and test suites</a></li>
-        <li><a href="http://code.google.com/p/pythonsed/">Repository</a></li>
+        <li><a href="https://github.com/GillesArcas/PythonSed">Repository</a></li>
         <li>Mail to: gilles dot arcas at gmail dot com</li>
         <li><a href="http://www.godrago.net/PersonalHub.html">Personal hub</a></li>
     </ul>

--- a/tests/testsuite4/indexhtml.good
+++ b/tests/testsuite4/indexhtml.good
@@ -109,7 +109,7 @@
         <li><a href="http://pythonsed.godrago.net">[1] Home page</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-py-1.00.zip">[2] Download script</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-tests-1.00.zip">[3] Download script and tests</a></li>
-        <li><a href="http://code.google.com/p/pythonsed/">[4] Repository</a></li>
+        <li><a href="https://github.com/GillesArcas/PythonSed">[4] Repository</a></li>
         <li>Mail to: gilles dot arcas at gmail dot com</li>
     </ul>
     <p style="font-size:1px">&nbsp;</p>
@@ -519,7 +519,7 @@ test-suite.py &lt;testsuite&gt; [number] [-b executable] [-x list of script refe
 <hr>[1] http://pythonsed.godrago.net<br>
 [2] http://pythonsed.godrago.net/pythonsed-py-1.00.zip<br>
 [3] http://pythonsed.godrago.net/pythonsed-tests-1.00.zip<br>
-[4] http://code.google.com/p/pythonsed/<br>
+[4] https://github.com/GillesArcas/PythonSed<br>
 [5] https://www.gnu.org/software/sed/manual/html_node/Other-Commands.html#Other-Commands<br>
 [6] https://www.gnu.org/software/sed/manual/html_node/Programming-Commands.html#Programming-Commands<br>
 [7] https://www.gnu.org/software/sed/manual/html_node/Programming-Commands.html#Programming-Commands<br>

--- a/tests/testsuite4/indexhtml.inp
+++ b/tests/testsuite4/indexhtml.inp
@@ -109,7 +109,7 @@
         <li><a href="http://pythonsed.godrago.net">Home page</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-py-1.00.zip">Download script</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-tests-1.00.zip">Download script and tests</a></li>
-        <li><a href="http://code.google.com/p/pythonsed/">Repository</a></li>
+        <li><a href="https://github.com/GillesArcas/PythonSed">Repository</a></li>
         <li>Mail to: gilles dot arcas at gmail dot com</li>
     </ul>
     <p style="font-size:1px">&nbsp;</p>

--- a/tests/testsuite4/list_urls.good
+++ b/tests/testsuite4/list_urls.good
@@ -6,7 +6,7 @@
 http://pythonsed.godrago.net
 http://pythonsed.godrago.net/pythonsed-py-1.00.zip
 http://pythonsed.godrago.net/pythonsed-tests-1.00.zip
-http://code.google.com/p/pythonsed/
+https://github.com/GillesArcas/PythonSed
 http://www.gnu.org/software/sed/manual/sed.html
 https://www.gnu.org/software/sed/manual/html_node/Other-Commands.html#Other-Commands
 https://www.gnu.org/software/sed/manual/html_node/Programming-Commands.html#Programming-Commands

--- a/tests/testsuite4/list_urls.inp
+++ b/tests/testsuite4/list_urls.inp
@@ -109,7 +109,7 @@
         <li><a href="http://pythonsed.godrago.net">Home page</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-py-1.00.zip">Download script</a></li>
         <li><a href="http://pythonsed.godrago.net/pythonsed-tests-1.00.zip">Download script and tests</a></li>
-        <li><a href="http://code.google.com/p/pythonsed/">Repository</a></li>
+        <li><a href="https://github.com/GillesArcas/PythonSed">Repository</a></li>
         <li>Mail to: gilles dot arcas at gmail dot com</li>
     </ul>
     <p style="font-size:1px">&nbsp;</p>


### PR DESCRIPTION
s/Google Code/GitHub/

Google search results for "sed python" and "python sed module"
point to the godrago.net website, who still points to the old
Google Code repo.

The sed.html file seems to be the source for that page.

The testsuite data was also updated for consistency.