### PR TITLE
Fix pythonsed tests not running in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - pip install coveralls
 
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION -le '3.6' ]]; then (coverage run tests/test-suite.py @all-tests.suites -x test-python-sed.exclude); fi
-  - if [[ $TRAVIS_PYTHON_VERSION -ge '3.7' ]]; then (coverage run tests/test-suite.py @all-tests.suites -x test-python-sed-3.7.exclude); fi
+  - if [ $TRAVIS_PYTHON_VERSION != '3.7' ]; then coverage run tests/test-suite.py @all-tests.suites -x test-python-sed.exclude; fi
+  - if [ $TRAVIS_PYTHON_VERSION = '3.7' ]; then coverage run tests/test-suite.py @all-tests.suites -x test-python-sed-3.7.exclude; fi
 
 after_success:
   - coveralls


### PR DESCRIPTION
Besides the Travis jobs finishing as OK, the pythonsed tests are not
running due a syntax error in the .travis.yml file.

    /home/travis/.travis/functions: line 104: [[: 3.6: syntax error: invalid arithmetic operator (error token is ".6")

This is shell script problem, who can't properly handle floating
point comparisons. Fixed that by using direct string comparison.

Now the pythonsed test suite is running in Travis.